### PR TITLE
Add query syntax for `in` queries

### DIFF
--- a/lib/api_monkey/filter_scopes.rb
+++ b/lib/api_monkey/filter_scopes.rb
@@ -22,7 +22,14 @@ module ApiMonkey::FilterScopes
     end
 
     def self.filter_args(field, value, op)
-      ["#{field} #{OPERANDS[op]} ?", value]
+      # I want to replace this right here...use polymorphism to build this string
+      # something like Operand.lookup(op).query_for(value) which would ultimately
+      # call `where` or `join().where` in the case of relationship filtering
+      if op == 'in'
+        ["#{field} in (?)", value]
+      else
+        ["#{field} #{OPERANDS[op]} ?", value]
+      end
     end
 
     def self.process_hash_params(field, param)

--- a/spec/filter_scopes_spec.rb
+++ b/spec/filter_scopes_spec.rb
@@ -47,6 +47,10 @@ describe 'FilterScopes Concern' do
     it 'includes the value for the associated predicate' do
       expect(FooModel.filter_args('amount', 0, 'eq')[1]).to eq 0
     end
+
+    it 'includes () for `in` queries' do
+      expect(FooModel.filter_args('amount', [0, 5, 10], 'in')).to eq ['amount in (?)', [0,5,10] ]
+    end
   end
 
   describe '#process_hash_params' do


### PR DESCRIPTION
## Problem

We currently don't support any filtering query like `where("amount in (?)", [x,y,z])`.  `in` requires the addition of the `()` wrapping the value which is unique to this kind of query.
## Solution

For now I'd like to simply add this support directly as I've done here (limiting the change made) in favor of a refactor soon to come as described in my comment on lines 25-27 of `lib/api_monkey/filter_scopes.rb` A change like I recommend would require changing `filter` in `/lib/api_monkey/filterable.rb` so that it does not expect parameters to a `where` method, but that it calls into the `FIlterScopes` API allowing it to call `where`, `joins`, etc. as need be.
