### PR TITLE
Setup CodeClimate coverage reporter

### DIFF
--- a/api_monkey.gemspec
+++ b/api_monkey.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/michaelkelly322/api_monkey"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '>= 1.9'
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
@@ -24,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "guard"
   spec.add_development_dependency "guard-rspec"
+  spec.add_development_dependency "codeclimate-test-reporter"
 
   spec.add_runtime_dependency 'activesupport'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 require 'bundler/setup'
 Bundler.setup
 
+require 'codeclimate-test-reporter'
+CodeClimate::TestReporter.start
+
 require 'api_monkey'
 
 RSpec.configure do |config|


### PR DESCRIPTION
## Problem

SInce development on this gem is stop/start, we need to setup auto builds and code eval to keep me honest
## Solution

Add Code Climate test coverage reporting.  Auto builds are being run by CodeShip (and the configuration is completely on the CodeShip side, no changes for this one)
